### PR TITLE
Added feature to switch to remote vcontrold

### DIFF
--- a/vcontrold/DOCS.md
+++ b/vcontrold/DOCS.md
@@ -12,7 +12,12 @@ Example: Writing a value to the topic `openv/setTempWWSoll` will set the target 
 ## Configuration
 
 ### Add-On Configuration
-In the configuration section, you need to set the USB/TTY device that uses an **Optolink** interface to connect to the **Vitodens** device. Select a _refresh rate_ that defines the interval used for polling your device and the _device id_ (typically also seen in the device identifier string) which is used to select the correct mapping for the commands that are executed.
+In the configuration section, you have 2 choices to connect to your **Vitodens** device using an an **Optolink** interface:
+1. For a locally connected **Optolink** cable, set the USB/TTY device. The add-on will pass through that USB port run **vcontrold** locally inside docker.
+2. For a remotely running **vcontrold** (e.g. RPi connected to your **Vitodens** device), select its hostname and port (_Vcontrold host/port_). These settings are by default set to localhost:3002.
+
+Select a _refresh rate_ that defines the interval used for polling your device and the _device id_ (typically also seen in the device identifier string) which is used to select the correct mapping for the commands that are executed.
+ 
 
 The commands section can be edited and extended in YAML mode, e.g.
 ```yaml

--- a/vcontrold/config.yaml
+++ b/vcontrold/config.yaml
@@ -15,7 +15,6 @@ options:
   tty: "/dev/ttyUSB0"
   refresh: 30
   device_id: "2098"
-  remote_vcontrol: false
   vcontrol_host: localhost
   vcontrol_port: 3002
   debug: false
@@ -61,11 +60,10 @@ schema:
   tty: "str"
   refresh: "int"
   device_id: "str"
-  remote_vcontrol: "bool"
-  vcontrol_host: "str"
-  vcontrol_port: "int"
-  debug: "bool"
-  commands: 
+  vcontrol_host: "str?"
+  vcontrol_port: "int?"
+  debug: "bool?"
+  commands:
     - "str"
 image: "alexandreio/{arch}-homeassistant-vcontrol"
 usb: true

--- a/vcontrold/config.yaml
+++ b/vcontrold/config.yaml
@@ -15,6 +15,9 @@ options:
   tty: "/dev/ttyUSB0"
   refresh: 30
   device_id: "2098"
+  remote_vcontrol: false
+  vcontrol_host: localhost
+  vcontrol_port: 3002
   debug: false
   commands:
     - getTempA:FLOAT
@@ -58,6 +61,9 @@ schema:
   tty: "str"
   refresh: "int"
   device_id: "str"
+  remote_vcontrol: "bool"
+  vcontrol_host: "str"
+  vcontrol_port: "int"
   debug: "bool"
   commands: 
     - "str"

--- a/vcontrold/rootfs/etc/services.d/vclient_pub/run
+++ b/vcontrold/rootfs/etc/services.d/vclient_pub/run
@@ -18,9 +18,13 @@ else
     export MQTT_PASSWORD=$(bashio::services mqtt "password")
     export MQTT_TOPIC="openv"
 
+    export VCONTROL_HOST=$(bashio::config 'vcontrol_host')
+    export VCONTROL_PORT=$(bashio::config 'vcontrol_port')
+    bashio::log.info "Setting vcontrold host to $VCONTROL_HOST and port to $VCONTROL_PORT ..."
+
     ## Run your program
     while sleep $refresh_rate; do
-        vclient -h 127.0.0.1 -p 3002 -f /etc/vcontrold/1_mqtt_commands.txt -t /etc/vcontrold/2_mqtt.tmpl -x /etc/vcontrold/3_mqtt_pub.sh
+        vclient -h $VCONTROL_HOST -p $VCONTROL_PORT -f /etc/vcontrold/1_mqtt_commands.txt -t /etc/vcontrold/2_mqtt.tmpl -x /etc/vcontrold/3_mqtt_pub.sh
         bashio::log.info "Looping vclient..."
     done
 fi

--- a/vcontrold/rootfs/etc/services.d/vclient_sub/run
+++ b/vcontrold/rootfs/etc/services.d/vclient_sub/run
@@ -18,6 +18,10 @@ else
     export MQTT_PASSWORD=$(bashio::services mqtt "password")
     export MQTT_TOPIC="openv"
 
+    bashio::log.info "Setting vcontrold host and port ..."
+    export VCONTROL_HOST=$(bashio::config 'vcontrol_host')
+    export VCONTROL_PORT=$(bashio::config 'vcontrol_port')
+
     ## Run your program
     while true ; do
         mosquitto_sub -v -h $MQTT_HOST -p $MQTT_PORT -u $MQTT_USER -P $MQTT_PASSWORD -t "$MQTT_TOPIC/#" | while read -r payload
@@ -28,7 +32,7 @@ else
             if [[ $topic =~ "/set" ]]; then
                 command=$(echo $topic | cut -d'/' -f2)
                 bashio::log.info "Sending command: [${command}]: ${value}"
-                vclient -h 127.0.0.1 -p 3002 -o /dev/stdout -c "${command} ${value}"
+                vclient -h $VCONTROL_HOST -p $VCONTROL_PORT -o /dev/stdout -c "${command} ${value}"
             fi
         done
         sleep $refresh_rate 

--- a/vcontrold/rootfs/etc/services.d/vcontrold/run
+++ b/vcontrold/rootfs/etc/services.d/vcontrold/run
@@ -9,14 +9,14 @@ declare config_tty
 declare config_deviceid
 declare config_commands
 declare config_debug
-declare remote_vcontrol
+declare vcontrol_host
 
 ## Get the 'message' key from the user config options.
 config_tty=$(bashio::config 'tty')
 config_deviceid=$(bashio::config 'device_id')
 config_debug=$(bashio::config 'debug')
 config_commands=$(bashio::config 'commands')
-remote_vcontrol=$(bashio::config 'remote_vcontrol')
+vcontrol_host=$(bashio::config 'vcontrol_host')
 
 # Cleanup scripts
 rm /etc/vcontrold/1_mqtt_commands.txt || /bin/true
@@ -54,10 +54,11 @@ else
     sed -i "s/#DEBUG#/n/g" /etc/vcontrold/vcontrold.xml
 fi
 
-bashio::log.info "Remote vcontrol set to $remote_vcontrol..."
-
 ## Run your program
-if [ "$remote_vcontrol" = "false" ] ; then
+if [ "$vcontrol_host" = "localhost" ] ; then
     bashio::log.info "Starting local vcontrold..."
     exec /usr/sbin/vcontrold -n -U root -d $config_tty
+else
+    # do nothing - needed as a dummy job to keep the dependency job running
+    tail -f /dev/null
 fi

--- a/vcontrold/rootfs/etc/services.d/vcontrold/run
+++ b/vcontrold/rootfs/etc/services.d/vcontrold/run
@@ -6,14 +6,17 @@
 
 # Declare variables
 declare config_tty
+declare config_deviceid
 declare config_commands
 declare config_debug
+declare remote_vcontrol
 
 ## Get the 'message' key from the user config options.
 config_tty=$(bashio::config 'tty')
 config_deviceid=$(bashio::config 'device_id')
 config_debug=$(bashio::config 'debug')
 config_commands=$(bashio::config 'commands')
+remote_vcontrol=$(bashio::config 'remote_vcontrol')
 
 # Cleanup scripts
 rm /etc/vcontrold/1_mqtt_commands.txt || /bin/true
@@ -51,5 +54,10 @@ else
     sed -i "s/#DEBUG#/n/g" /etc/vcontrold/vcontrold.xml
 fi
 
+bashio::log.info "Remote vcontrol set to $remote_vcontrol..."
+
 ## Run your program
-exec /usr/sbin/vcontrold -n -U root -d $config_tty
+if [ "$remote_vcontrol" = "false" ] ; then
+    bashio::log.info "Starting local vcontrold..."
+    exec /usr/sbin/vcontrold -n -U root -d $config_tty
+fi

--- a/vcontrold/translations/de.yaml
+++ b/vcontrold/translations/de.yaml
@@ -8,10 +8,7 @@ configuration:
   device_id:
     name: "Device ID"
     description: "Viessmann Gerätekennung (2098 => V200KW2 , 2053 => GWG_VBEM, 20CB => VScotHO1 , 2094 => V200KW1)"
-  remote_vcontrol:
-    name: "Connect to remote vcontrold"
-    description: "An, falls mit vcontrold auf anderem Rechner verbunden werden soll und aus, um vcontrold auf localhost zu starten (z.B. bei verbundenem Optolink-Kabel)"
-  vcontrol_host:
+vcontrol_host:
     name: "Vcontrold Host"
     description: "vcontrold host für die Verbindung (default: localhost)"
   vcontrol_port:

--- a/vcontrold/translations/de.yaml
+++ b/vcontrold/translations/de.yaml
@@ -8,6 +8,15 @@ configuration:
   device_id:
     name: "Device ID"
     description: "Viessmann Gerätekennung (2098 => V200KW2 , 2053 => GWG_VBEM, 20CB => VScotHO1 , 2094 => V200KW1)"
+  remote_vcontrol:
+    name: "Connect to remote vcontrold"
+    description: "An, falls mit vcontrold auf anderem Rechner verbunden werden soll und aus, um vcontrold auf localhost zu starten (z.B. bei verbundenem Optolink-Kabel)"
+  vcontrol_host:
+    name: "Vcontrold Host"
+    description: "vcontrold host für die Verbindung (default: localhost)"
+  vcontrol_port:
+    name: "Vcontrold Port"
+    description: "vcontrold für die Verbindung (default: 3002)"
   debug:
     name: "Debug"
     description: "Ausgabe von Debug-Nachrichten"

--- a/vcontrold/translations/en.yaml
+++ b/vcontrold/translations/en.yaml
@@ -8,9 +8,6 @@ configuration:
   device_id:
     name: "Device ID"
     description: "The device identifier. (2098 => V200KW2 , 2053 => GWG_VBEM, 20CB => VScotHO1 , 2094 => V200KW1)"
-  remote_vcontrol:
-    name: "Connect to remote vcontrold"
-    description: "Set to true if you want to connect to a remote vcontrold and false to run vcontrold on localhost (e.g. Optolink cable connected)"
   vcontrol_host:
     name: "Vcontrold Host"
     description: "vcontrold host to connect to (default: localhost)"

--- a/vcontrold/translations/en.yaml
+++ b/vcontrold/translations/en.yaml
@@ -8,6 +8,15 @@ configuration:
   device_id:
     name: "Device ID"
     description: "The device identifier. (2098 => V200KW2 , 2053 => GWG_VBEM, 20CB => VScotHO1 , 2094 => V200KW1)"
+  remote_vcontrol:
+    name: "Connect to remote vcontrold"
+    description: "Set to true if you want to connect to a remote vcontrold and false to run vcontrold on localhost (e.g. Optolink cable connected)"
+  vcontrol_host:
+    name: "Vcontrold Host"
+    description: "vcontrold host to connect to (default: localhost)"
+  vcontrol_port:
+    name: "Vcontrold Port"
+    description: "vcontrold port to connect to (default: 3002)"
   debug:
     name: "Debug"
     description: "Output of debug messages"


### PR DESCRIPTION
Added feature to switch to remote vcontrold instead of running it locally. Uses a config flag and host/port for connection with defaults to localhost:3002, see https://github.com/Alexandre-io/homeassistant-vcontrol/issues/9