### PR TITLE
Fix error code check

### DIFF
--- a/vcontrold/config.yaml
+++ b/vcontrold/config.yaml
@@ -1,6 +1,6 @@
 # https://developers.home-assistant.io/docs/add-ons/configuration#add-on-config
 name: Vcontrol add-on
-version: "1.8.1"
+version: "1.8.2"
 slug: vcontrold
 description: Vcontrol add-on
 url: "https://github.com/Alexandre-io/homeassistant-vcontrol"

--- a/vcontrold/rootfs/etc/services.d/vcontrold/run
+++ b/vcontrold/rootfs/etc/services.d/vcontrold/run
@@ -40,7 +40,7 @@ do
         R='"$R'$i'"'
     fi
 
-    echo 'if [ "x$E'$i'" = x ]; then' >> /etc/vcontrold/2_mqtt.tmpl
+    echo 'if [ "x$E'$i'" = "xOK" ]; then' >> /etc/vcontrold/2_mqtt.tmpl
     echo '  mosquitto_pub -h $MQTT_HOST -p $MQTT_PORT -u $MQTT_USER -P $MQTT_PASSWORD -t $MQTT_TOPIC/$C'$i' -m '$R'' >> /etc/vcontrold/2_mqtt.tmpl
     echo 'fi' >> /etc/vcontrold/2_mqtt.tmpl
 done


### PR DESCRIPTION
Hi @Alexandre-io , 

another bug: 
On my setup, vcontrold sets $E1... to "OK" if the command is succesful. So the check 
 [ "x$E'$i'" = x ]
will be substituted to
 [ "xOK" = x ] 
which is of course never true. 

With the below fix, I do have a running setup again.

I am not sure whether my vcontrold (remote one) is in some sense special here - so if the below bugfix is actually only a fix for me - or whether its a general bugfix.

