### PR TITLE
Added getTempRaumIstA1M1 reading

### DIFF
--- a/vcontrold/rootfs/etc/vcontrold/vito.xml
+++ b/vcontrold/rootfs/etc/vcontrold/vito.xml
@@ -34,6 +34,15 @@
       <description>Ermittle die Aussentemperatur in Grad C (Gedaempft)</description>
       <device ID="2053"/>
     </command>
+    <command name="getTempRaumIstA1M1" protocmd="getaddr">
+      <addr>0896</addr>
+      <len>2</len>
+      <unit>UT</unit>
+      <description>Ermittle die tatsaechliche Raumtemperatur in Grad C (nur mit Fernbedienung Vitotrol 200/300)</description>
+      <device ID="2094" />
+      <device ID="2098" />
+      <device ID="20CB" />
+    </command>
     <!-- WARMWASSER -->
     <command name="getTempWWist" protocmd="getaddr">
       <addr>0804</addr>


### PR DESCRIPTION
I added the reading for determining the actual room temperature, given a Vitotrol 200/300 remote is connected to the heating. I'm using this in my own home automation setup with vcontrold and a Vitodens 300-W - so I can confirm it is working at least with the 20CB protocol (VScotHO1). But according to https://github.com/openv/openv/wiki/Adressen the reading should work as well with V200KW1 (2094) and V200KW2 (2098), thus I added these three protocols to the config.

Would be great to have this reading in the next release of vcontrold for Home Assistant (I am currently migrating to HA from FHEM, and vcontrold integration is crucial for me :) ).