### PR TITLE
Allow multiple parameters for MQTT commands

### DIFF
--- a/vcontrold/rootfs/etc/services.d/vclient_sub/run
+++ b/vcontrold/rootfs/etc/services.d/vclient_sub/run
@@ -24,7 +24,7 @@ while true ; do
     do
         # Here is the callback to execute whenever you receive a message:
         topic=$(echo $payload | cut -d' ' -f1)
-        value=$(echo $payload | cut -d' ' -f2)
+        value=$(echo $payload | cut -d' ' -f2-)
         if [[ $topic =~ "/set" ]]; then
             command=$(echo $topic | cut -d'/' -f2)
             bashio::log.info "Sending command: [${command}]: ${value}"
@@ -39,7 +39,7 @@ while true; do
     mosquitto_sub -v -h "$MQTT_HOST" -p "$MQTT_PORT" -u "$MQTT_USER" -P "$MQTT_PASSWORD" -t "$MQTT_TOPIC/#" | while read -r payload; do
         # Parse the incoming MQTT message
         topic=$(echo "$payload" | cut -d' ' -f1)
-        value=$(echo "$payload" | cut -d' ' -f2)
+        value=$(echo "$payload" | cut -d' ' -f2-)
 
         # Process only topics containing "/set"
         if [[ "$topic" =~ "/set" ]]; then


### PR DESCRIPTION
Some commands like "setTimerM1Mo" require more than one parameter (this specific one can take up to 8 parameters).
Currently only the first parameter is evaluated, so e.g.
  "setTimerM1Mo 06:00 08:00 10:00 12:00"
results in
  "setTimerM1Mo 06:00"

Changing the "cut" statement from "-f2" to "-f2-" will pass all parameters after the first delimiter instead of just the next one.